### PR TITLE
Update iwave-5.4.24-2.1.0-iwg27s-r2.0-rel0.1.xml

### DIFF
--- a/iwave-5.4.24-2.1.0-iwg27s-r2.0-rel0.1.xml
+++ b/iwave-5.4.24-2.1.0-iwg27s-r2.0-rel0.1.xml
@@ -4,13 +4,13 @@
   <default sync-j="2"/>
 
   <remote fetch="https://git.yoctoproject.org/git" name="yocto"/>
-  <remote fetch="git://github.com/Freescale" name="community"/>
-  <remote fetch="git://github.com/openembedded" name="oe"/>
-  <remote fetch="git://github.com/OSSystems" name="OSSystems"/>
-  <remote fetch="git://github.com/meta-qt5"  name="QT5"/>
-  <remote fetch="git://github.com/TimesysGit"  name="Timesys"/>
-  <remote fetch="git://github.com/meta-rust"  name="rust"/>
-  <remote fetch="git://git.openembedded.org"  name="python2"/>
+  <remote fetch="https://github.com/Freescale" name="community"/>
+  <remote fetch="https://github.com/openembedded" name="oe"/>
+  <remote fetch="https://github.com/OSSystems" name="OSSystems"/>
+  <remote fetch="https://github.com/meta-qt5"  name="QT5"/>
+  <remote fetch="https://github.com/TimesysGit"  name="Timesys"/>
+  <remote fetch="https://github.com/meta-rust"  name="rust"/>
+  <remote fetch="https://git.openembedded.org"  name="python2"/>
   <remote fetch="https://source.codeaurora.org/external/imx" name="CAF"/>
   <remote fetch="https://github.com/iwave-git" name="iwave"/>
 


### PR DESCRIPTION
Changed git:// url to https:// url due to update in git security protocol -- https://github.blog/2021-09-01-improving-git-protocol-security-github/